### PR TITLE
[codex] Respect configured ComfyUI model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ A working generation environment needs these imports inside the same Python that
 | RMBG-2.0 | `ComfyUI/models/Pixal3D/briaai_RMBG-2.0/` | Gated model; only needed for `background_mode=auto_remove` |
 | NATTEN/libnatten | `natten.HAS_LIBNATTEN == True` | Only needed for strict NAF |
 
+### Model search paths with `extra_model_paths_config`
+
+Pixal3D-ComfyUI supports the default `ComfyUI/models/Pixal3D` folder. If you keep models outside the default `ComfyUI/models` folder through `--extra-model-paths-config`, add explicit Pixal3D entries to that config:
+
+```yaml
+comfyui:
+  base_path: /path/to/shared/root
+  Pixal3D: models/Pixal3D
+  geometry_estimation: models/geometry_estimation
+```
+
+Do not rely on Pixal3D-ComfyUI guessing a model root from unrelated model folders. The Pixal3D loader searches the registered `Pixal3D` folder, or the default `ComfyUI/models/Pixal3D` folder when no custom `Pixal3D` folder is registered. Native MoGe searches the registered `geometry_estimation` folder.
+
 If Environment Check says a CUDA package is missing, install a wheel that exactly matches your stack. Do not let pip replace a working Torch install while testing random wheels; use `--no-deps` for manual CUDA wheels.
 
 ## Windows Wheel Order

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -47,6 +47,19 @@ python install.py --check
 | RMBG-2.0 | `ComfyUI/models/Pixal3D/briaai_RMBG-2.0/` | gated model；只在 `background_mode=auto_remove` 时需要 |
 | NATTEN/libnatten | `natten.HAS_LIBNATTEN == True` | 只在 strict NAF 时需要 |
 
+### 使用 `extra_model_paths_config` 时的模型搜索路径
+
+Pixal3D-ComfyUI 支持默认的 `ComfyUI/models/Pixal3D` 目录。如果你通过 `--extra-model-paths-config` 把模型放在默认 `ComfyUI/models` 之外，请在配置里显式添加 Pixal3D 相关条目：
+
+```yaml
+comfyui:
+  base_path: /path/to/shared/root
+  Pixal3D: models/Pixal3D
+  geometry_estimation: models/geometry_estimation
+```
+
+不要依赖 Pixal3D-ComfyUI 从其他模型目录猜测模型根目录。Pixal3D loader 会搜索已注册的 `Pixal3D` 目录；如果没有自定义 `Pixal3D` 注册目录，则使用默认的 `ComfyUI/models/Pixal3D`。原生 MoGe 会搜索已注册的 `geometry_estimation` 目录。
+
 手动安装 CUDA 轮子时使用 `--no-deps`，避免 pip 替换已经可用的 Torch。
 
 ## Windows 轮子顺序

--- a/pixal3d_comfy/runtime.py
+++ b/pixal3d_comfy/runtime.py
@@ -303,8 +303,10 @@ def _sanitize_module_name(name: str) -> str:
 
 def environment_report() -> str:
     lines = ["Pixal3D-ComfyUI environment check", ""]
-    lines.append(f"ComfyUI models/Pixal3D: {pixal3d_models_dir()}")
-    lines.append(f"ComfyUI models/geometry_estimation: {moge_models_dir()}")
+    lines.append("ComfyUI models/Pixal3D search paths:")
+    lines.extend(f"- {path}" for path in pixal3d_model_dirs())
+    lines.append("ComfyUI models/geometry_estimation search paths:")
+    lines.extend(f"- {path}" for path in moge_model_dirs())
     lines.append(f"Nodepack path: {_repo_root()}")
     lines.append("")
 
@@ -378,23 +380,69 @@ def environment_report() -> str:
     return "\n".join(lines)
 
 
-def pixal3d_models_dir() -> Path:
-    models_dir = Path(folder_paths.models_dir) / "Pixal3D"
-    models_dir.mkdir(parents=True, exist_ok=True)
+def _get_folder_paths(folder_name: str) -> list[Path]:
     try:
-        folder_paths.add_model_folder_path("Pixal3D", str(models_dir))
+        return [Path(path) for path in folder_paths.get_folder_paths(folder_name)]
     except Exception:
-        pass
+        return []
+
+
+def _unique_paths(paths: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = os.path.normcase(os.path.abspath(str(path)))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def pixal3d_model_dirs() -> list[Path]:
+    paths = _get_folder_paths("Pixal3D")
+    if paths:
+        return _unique_paths(paths)
+    # Pixal3D is not a built-in ComfyUI model folder type, so installations
+    # that use the default ComfyUI/models tree will not have it registered by
+    # core. Keep supporting the documented default location without guessing
+    # external/shared model roots.
+    return [Path(folder_paths.models_dir) / "Pixal3D"]
+
+
+def pixal3d_models_dir() -> Path:
+    paths = pixal3d_model_dirs()
+    if not paths:
+        raise FileNotFoundError(
+            "Pixal3D model path is not configured. Place models under the default ComfyUI/models/Pixal3D folder, "
+            "or add a Pixal3D entry to your ComfyUI extra_model_paths_config, for example:\n"
+            "comfyui:\n"
+            "  base_path: /path/to/ComfyUI-or-shared-root\n"
+            "  Pixal3D: models/Pixal3D"
+        )
+    models_dir = paths[0]
+    models_dir.mkdir(parents=True, exist_ok=True)
     return models_dir
 
 
+def moge_model_dirs() -> list[Path]:
+    geometry_dirs = _get_folder_paths(NATIVE_COMFY_MOGE_SUBDIR)
+    legacy_moge_dirs = _get_folder_paths("moge")
+    return _unique_paths([*geometry_dirs, *legacy_moge_dirs])
+
+
 def moge_models_dir() -> Path:
-    models_dir = Path(folder_paths.models_dir) / NATIVE_COMFY_MOGE_SUBDIR
+    paths = moge_model_dirs()
+    if not paths:
+        raise FileNotFoundError(
+            "Native ComfyUI MoGe path is not configured. Add a geometry_estimation entry to your ComfyUI "
+            "extra_model_paths_config, for example:\n"
+            "comfyui:\n"
+            "  base_path: /path/to/ComfyUI-or-shared-root\n"
+            "  geometry_estimation: models/geometry_estimation"
+        )
+    models_dir = paths[0]
     models_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        folder_paths.add_model_folder_path("moge", str(models_dir))
-    except Exception:
-        pass
     return models_dir
 
 
@@ -443,7 +491,6 @@ def _snapshot_subdirs(cache_dir: Path) -> list[Path]:
 
 
 def _candidate_snapshot_dirs(repo_id: str) -> list[Path]:
-    root = pixal3d_models_dir()
     candidates: list[Path] = []
     for name in dict.fromkeys(
         [
@@ -452,9 +499,10 @@ def _candidate_snapshot_dirs(repo_id: str) -> list[Path]:
             _repo_cache_folder_name(repo_id),
         ]
     ):
-        candidate = root / name
-        candidates.append(candidate)
-        candidates.extend(_snapshot_subdirs(candidate))
+        for root in pixal3d_model_dirs():
+            candidate = root / name
+            candidates.append(candidate)
+            candidates.extend(_snapshot_subdirs(candidate))
     return candidates
 
 
@@ -546,15 +594,21 @@ def _download_hf_file_to_path(repo_id: str, remote_filename: str, destination: P
 
 def _remove_snapshot_metadata(target: Path) -> None:
     target = target.resolve()
-    root = pixal3d_models_dir().resolve()
-    try:
-        target.relative_to(root)
-    except ValueError:
+    roots = [root.resolve() for root in pixal3d_model_dirs()]
+    if not any(_is_relative_to(target, root) for root in roots):
         return
     for name in (".cache", ".git"):
         metadata_dir = target / name
         if metadata_dir.exists() and metadata_dir.is_dir():
             shutil.rmtree(metadata_dir, ignore_errors=True)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
 
 
 def resolve_model_path(model_repo: str, download_if_missing: bool, hf_endpoint: str = "") -> str:
@@ -646,7 +700,6 @@ def resolve_native_comfy_moge_path(
         repo_id = NATIVE_COMFY_MOGE_REPO
 
     target_dir = moge_models_dir()
-    legacy_dir = Path(folder_paths.models_dir) / "moge"
 
     if download_if_missing:
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -656,12 +709,16 @@ def resolve_native_comfy_moge_path(
                 LOGGER.info("Downloading native ComfyUI MoGe file %s from %s to %s", remote_filename, repo_id, destination)
                 _download_hf_file_to_path(repo_id, remote_filename, destination, hf_endpoint)
 
-    for search_dir in (target_dir, legacy_dir):
+    for search_dir in moge_model_dirs():
         required_path = search_dir / NATIVE_COMFY_MOGE_MODEL
         if required_path.exists() and required_path.is_file():
             return str(required_path)
 
-    expected = "\n".join(str(target_dir / filename) for filename in NATIVE_COMFY_MOGE_FILES)
+    expected = "\n".join(
+        str(search_dir / filename)
+        for search_dir in moge_model_dirs()
+        for filename in NATIVE_COMFY_MOGE_FILES
+    )
     raise FileNotFoundError(
         "Native ComfyUI MoGe is missing.\n"
         f"Download link: https://huggingface.co/{NATIVE_COMFY_MOGE_REPO}\n"


### PR DESCRIPTION
## Summary

- Use ComfyUI-registered `Pixal3D` model folder paths when configured.
- Keep support for the documented default `ComfyUI/models/Pixal3D` location when no custom `Pixal3D` folder is registered.
- Use ComfyUI-registered `geometry_estimation` / legacy `moge` paths for native MoGe files.
- Update the environment check report to show the full search path order.
- Document explicit `extra_model_paths_config` entries for shared/external model roots.

## Why

`extra_model_paths_config` registers model-type directories, but it does not mutate `folder_paths.models_dir`. In portable or shared-model-root setups, users may have models under an external root such as `F:/comfy/models` while `folder_paths.models_dir` remains `F:/comfy/ComfyUI/models`. Pixal3D then reports that `pipeline.json` is missing even though the model exists under the configured model root.

This PR keeps the normal default-location behavior for users who place models under `ComfyUI/models/Pixal3D`, but requires explicit registration when models live outside the default ComfyUI model directory, for example:

```yaml
comfyui:
  base_path: F:/comfy
  Pixal3D: models/Pixal3D
  geometry_estimation: models/geometry_estimation
```

This avoids guessing model roots from unrelated model folders while still supporting the default ComfyUI models tree.

## Validation

- `python -m py_compile pixal3d_comfy/runtime.py`
- `git diff --check`
- Local path-resolution smoke test with explicit `Pixal3D` and `geometry_estimation` entries in `F:\\comfy\\extra.yaml` showing:
  - Pixal3D search order starts with `F:\\comfy\\models\\Pixal3D`
  - MoGe search order starts with `F:\\comfy\\models\\geometry_estimation`
  - `resolve_model_path("TencentARC/Pixal3D", False)` resolves to the configured external Pixal3D folder
  - `resolve_native_comfy_moge_path("Comfy-Org/MoGe", False)` resolves to the configured external geometry_estimation folder
- Local smoke test without a custom `Pixal3D` registration showing Pixal3D falls back only to the documented default `folder_paths.models_dir / "Pixal3D"` path